### PR TITLE
Update Certificate base resource

### DIFF
--- a/pystackpath/certificates.py
+++ b/pystackpath/certificates.py
@@ -1,62 +1,55 @@
 from .util import BaseObject, PageInfo, pagination_query
 
+
 class Certificates(BaseObject):
         def index(self, first="", after="", filter="", sort_by=""):
             pagination = pagination_query(first=first, after=after, filter=filter, sort_by=sort_by)
             response = self._client.get(f"/cdn/v1/stacks/{self._parent_id}/certificates", params=pagination)
             response.raise_for_status()
-            items = []
-            for item in response.json()["results"]:
-                items.append(self.loaddict(item))
+
+            items = list(map(lambda x: self.loaddict(x), response.json()["results"]))
             pageinfo = PageInfo(**response.json()["pageInfo"])
 
             return {"results": items, "pageinfo": pageinfo}
 
-
-        def get(self, certificate_id):
+        def get(self, certificate_id: str):
             response = self._client.get(f"/cdn/v1/stacks/{self._parent_id}/certificates/{certificate_id}")
             response.raise_for_status()
 
             return self.loaddict(response.json()["certificate"])
 
-
-        def add(self, certificate_string, key_string, ca_bundle_string = None):
-
+        def add(self, certificate_string: str, key_string: str, ca_bundle_string: str = None):
             data = {
                 "certificate" : certificate_string,
                 "key" : key_string,
                 "caBundle" : ca_bundle_string
             }
 
-            response = self._client.post(f"/cdn/v1/stacks/{self._parent_id}/certificates", json = data)
+            response = self._client.post(f"/cdn/v1/stacks/{self._parent_id}/certificates", json=data)
             response.raise_for_status()
 
             return self.loaddict(response.json()["certificate"])
 
-        def delete(self, certificate_id):
-
-            response = self._client.delete(f"/cdn/v1/stacks/{self._parent_id}/certificates/{certificate_id}" )
+        def delete(self):
+            response = self._client.delete(f"/cdn/v1/stacks/{self._parent_id}/certificates/{self.id}")
             response.raise_for_status()
 
             return self
 
-        def update(self, certificate_id, certificate_string = None, key_string = None, ca_bundle_string = None):
-
+        def update(self, certificate_string = None, key_string = None, ca_bundle_string: str = None):
             data = {
                 "certificate" : certificate_string,
                 "key" : key_string,
                 "caBundle" : ca_bundle_string
             }
 
-            response = self._client.put(f"/cdn/v1/stacks/{self._parent_id}/certificates/{certificate_id}",
-                json = data )
+            response = self._client.put(f"/cdn/v1/stacks/{self._parent_id}/certificates/{self.id}", json=data)
             response.raise_for_status()
 
             return self.loaddict(response.json()["certificate"])
 
-        def renew(self, certificate_id):
-
-            response = self._client.post(f"/cdn/v1/stacks/{self._parent_id}/certificates/{certificate_id}/renew")
+        def renew(self):
+            response = self._client.post(f"/cdn/v1/stacks/{self._parent_id}/certificates/{self.id}/renew")
             response.raise_for_status()
 
-            return response
+            return self


### PR DESCRIPTION
**Did you labeled this PR?**
YES

**What this PR does / why we need it**:
Using same structure we're using for other resources: we don't need to pass ID to perform actions like DELETE or UPDATE.

Plus, little fixes like PEP-8 and using lambda/map (to avoid useless `for` loop)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Certificate resources now don't need the certificate ID to perform the following operations:
- `update`
- `delete`
- `renew`

Moreover, the `renew` method doesn't return the response, rather itself since it's a `204` response.
```