### PR TITLE
feature: forcefully assign a Certificate to a Site

### DIFF
--- a/pystackpath/stacks/cdnsites/__init__.py
+++ b/pystackpath/stacks/cdnsites/__init__.py
@@ -1,6 +1,7 @@
-from pystackpath.util import BaseSite
 from pystackpath.stacks.cdnsites.scopes import Scopes
 from pystackpath.stacks.certificates import Certificates
+from pystackpath.util import BaseSite
+
 
 class CdnSites(BaseSite):
     def index(self, first="", after="", filter="", sort_by=""):

--- a/pystackpath/stacks/cdnsites/__init__.py
+++ b/pystackpath/stacks/cdnsites/__init__.py
@@ -69,7 +69,7 @@ class CdnSites(BaseSite):
         response = self._client.put(f"{self._base_api}/sites/{self.id}/certificates/{certificate.id}")
         response.raise_for_status()
 
-        return self.loaddict(response.json()["siteCertificate"]["certificate"])
+        return Certificates(self._client, f"{self._base_api}/certificates").loaddict(response.json()["siteCertificate"]["certificate"])
 
     def scopes(self):
         return Scopes(self._client, f"{self._base_api}/sites/{self.id}")

--- a/pystackpath/stacks/cdnsites/__init__.py
+++ b/pystackpath/stacks/cdnsites/__init__.py
@@ -1,6 +1,6 @@
 from pystackpath.util import BaseSite
 from pystackpath.stacks.cdnsites.scopes import Scopes
-
+from pystackpath.stacks.certificates import Certificates
 
 class CdnSites(BaseSite):
     def index(self, first="", after="", filter="", sort_by=""):
@@ -58,6 +58,17 @@ class CdnSites(BaseSite):
         response = self._client.post(f"{self._base_api}/sites/{self.id}/enable")
         response.raise_for_status()
         return self
+
+    def assign_certificate(self, certificate: Certificates):
+        """
+        Assign (and eventually force) a Certificate for the current Site.
+        :param certificate:
+        :return:
+        """
+        response = self._client.put(f"{self._base_api}/sites/{self.id}/certificates/{certificate.id}")
+        response.raise_for_status()
+
+        return self.loaddict(response.json()["siteCertificate"]["certificate"])
 
     def scopes(self):
         return Scopes(self._client, f"{self._base_api}/sites/{self.id}")

--- a/pystackpath/stacks/cdnsites/__init__.py
+++ b/pystackpath/stacks/cdnsites/__init__.py
@@ -69,7 +69,8 @@ class CdnSites(BaseSite):
         response = self._client.put(f"{self._base_api}/sites/{self.id}/certificates/{certificate.id}")
         response.raise_for_status()
 
-        return Certificates(self._client, f"{self._base_api}/certificates").loaddict(response.json()["siteCertificate"]["certificate"])
+        certificate = Certificates(self._client, f"{self._base_api}/certificates")
+        return certificate.loaddict(response.json()["siteCertificate"]["certificate"])
 
     def scopes(self):
         return Scopes(self._client, f"{self._base_api}/sites/{self.id}")


### PR DESCRIPTION
**Did you labeled this PR?**
YES

**What this PR does / why we need it**:
Although the [doc](https://developer.stackpath.com/en/api/cdn/#operation/ConnectSiteToCertificate) states

> If a certificate is uploaded which contains hostnames for sites, it will automatically be connected to those sites

we should be able to force a certificate association:

> Association is performed without validating if the site has a hostname covered by the certificate.
> This is useful for preparation work required for getting a site ready for traffic.

The aim of this PR is this last point.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Adding the ability fo forcefully assign a Certificate resource for a given Site.
```